### PR TITLE
Require Node.js 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,17 @@
   },
   "homepage": "https://github.com/bcoe/dotgitignore#readme",
   "dependencies": {
-    "find-up": "^2.1.0",
+    "find-up": "^3.0.0",
     "minimatch": "^3.0.4"
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "mocha": "^4.1.0",
-    "nyc": "^11.4.1",
-    "standard": "^10.0.3",
-    "standard-version": "^4.3.0-candidate.1"
+    "mocha": "^5.2.0",
+    "nyc": "^12.0.2",
+    "standard": "^11.0.1",
+    "standard-version": "^4.4.0"
+  },
+  "engines": {
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
This PR drops support for the now EOL version 4.x of Node.js. It allows this library to depend on a newer `find-up`, which depends on a newer `locate-path`, which depends on a newer `p-locate`, which depends on a newer `p-limit`, which has some performance improvements which in turn depends on a newer `p-try`.

This should be released as a new major version since it drops support for a previously supported runtime.

Would love to get this merged and released so that it can be included in istanbuljs/nyc#866. Currently, it has duplicates of `p-try`, `p-limit`, etc. since some packages have moved to the new one.

Cheers 👋 